### PR TITLE
Support empty fcm token

### DIFF
--- a/internal/api/browser_extension/app/command/request_2fa_token.go
+++ b/internal/api/browser_extension/app/command/request_2fa_token.go
@@ -86,6 +86,18 @@ func (h *Request2FaTokenHandler) Handle(cmd *Request2FaToken) error {
 	}
 
 	for _, device := range pairedDevices {
+		if device.FcmToken == "" {
+			logging.WithFields(logging.Fields{
+				"extension_id":     extId.String(),
+				"device_id":        device.Id.String(),
+				"token_request_id": cmd.Id,
+				"domain":           cmd.Domain,
+				"platform":         device.Platform,
+				"type":             "browser_extension_request",
+			}).Info("Cannot send push notification, missing FCM token")
+			continue
+		}
+
 		var err error
 		var notification *messaging.Message
 

--- a/internal/api/mobile/app/command/register_mobile_device.go
+++ b/internal/api/mobile/app/command/register_mobile_device.go
@@ -9,7 +9,7 @@ type RegisterMobileDevice struct {
 	Id       uuid.UUID
 	Name     string `json:"name" validate:"not_blank,max=128"`
 	Platform string `json:"platform" validate:"required,oneof=ios android huawei"`
-	FcmToken string `json:"fcm_token" validate:"required,max=256"`
+	FcmToken string `json:"fcm_token" validate:"max=256"`
 }
 
 type RegisterMobileDeviceHandler struct {

--- a/tests/mobile/mobile_device_test.go
+++ b/tests/mobile/mobile_device_test.go
@@ -25,28 +25,29 @@ func (s *MobileDeviceTestSuite) SetupTest() {
 func (s *MobileDeviceTestSuite) TestCreateMobileDevice() {
 	type testCase struct {
 		deviceName       string
+		fcmToken         string
 		expectedHttpCode int
 	}
-
+	defaultFCMToken := "some-fake-token"
 	testsCases := []testCase{
-		{deviceName: "", expectedHttpCode: 400},
-		{deviceName: " ", expectedHttpCode: 400},
-		{deviceName: "   ", expectedHttpCode: 400},
-		{deviceName: "john`s android", expectedHttpCode: 200},
-		{deviceName: "john ", expectedHttpCode: 200},
-		{deviceName: " john doe", expectedHttpCode: 200},
+		{deviceName: "", fcmToken: defaultFCMToken, expectedHttpCode: 400},
+		{deviceName: " ", fcmToken: defaultFCMToken, expectedHttpCode: 400},
+		{deviceName: "   ", fcmToken: defaultFCMToken, expectedHttpCode: 400},
+		{deviceName: "john`s android", fcmToken: defaultFCMToken, expectedHttpCode: 200},
+		{deviceName: "john ", fcmToken: defaultFCMToken, expectedHttpCode: 200},
+		{deviceName: " john doe", fcmToken: defaultFCMToken, expectedHttpCode: 200},
+		// empty FCM token should be also valid.
+		{deviceName: " john doe", fcmToken: "", expectedHttpCode: 200},
 	}
 
 	for _, tc := range testsCases {
-		response := createDevice(s.T(), tc.deviceName)
+		response := createDevice(s.T(), tc.deviceName, tc.fcmToken)
 
 		assert.Equal(s.T(), tc.expectedHttpCode, response.StatusCode)
 	}
 }
 
-func createDevice(t *testing.T, name string) *http.Response {
-	fcmToken := "some-fake-token"
+func createDevice(t *testing.T, name, fcmToken string) *http.Response {
 	payload := []byte(fmt.Sprintf(`{"name":"%s","platform":"android","fcm_token":"%s"}`, name, fcmToken))
-
 	return tests.DoAPIRequest(t, "mobile/devices", http.MethodPost, payload, nil)
 }


### PR DESCRIPTION
# What

Add should support for empty fcm token when creating device.

There are cases when mobile app cannot connect to firebase, but we want to proceed further with pairing, and just don't trigger push notification if fcm token is empty.

It's already supported of sql schema level. 