### PR TITLE
Add links to issue creation page

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Help center
+    url: https://2fas.com/help-center/
+    about: Check out our extensive FaQ and video guides!
+  - name: Discord
+    url: https://discord.gg/q4cP6qh2g5
+    about: Need support or have a question? Our Discord members are there to help!
+  - name: Reddit
+    url: https://www.reddit.com/r/2fas_com/
+    about: Get support and discuss 2FAS with our Reddit community!


### PR DESCRIPTION
If you want to add issue templates, you can look at [this PR in the twofas-2fas-ios repo](https://github.com/twofas/2fas-ios/pull/84) and work off of those files for consistency between issue templates within the 2fas repositories. (I can't PR them here bec I don't know how issues should look for a backend.)

**Web view**

![image](https://github.com/twofas/2fas-server/assets/84587632/a2d9b680-cc56-4ca2-b10a-71962f8cba7a)

**App view**

<img src="https://github.com/twofas/2fas-server/assets/84587632/6214b212-81ba-4541-8564-c2fcfa8a5712" height="500">